### PR TITLE
Typo fix in /markdown/README.md

### DIFF
--- a/markdown/README.md
+++ b/markdown/README.md
@@ -1,6 +1,6 @@
 # Markdown
 
-GitBook use by default the Markdown syntax.
+GitBook uses the Markdown syntax by default.
 
 This is intended as a quick reference and showcase. For more complete info, see [John Gruber's original spec](http://daringfireball.net/projects/markdown/) and the [Github-flavored Markdown info page](http://github.github.com/github-flavored-markdown/).
 


### PR DESCRIPTION
There was a small typo in the /markdown/README.md file that I saw when I was reading the documentation in the first line.