### PR TITLE
Fixing read me link under Format.

### DIFF
--- a/format/README.md
+++ b/format/README.md
@@ -4,7 +4,7 @@ The format's main focus is simplicity and readability.
 
 GitBook uses a convention on top of markup files:
 
-* [**README**](./readme.md): Introduction of the book
+* [**README**](./introduction.md): Introduction of the book
 * [**SUMMARY**](./chapters.md): Chapters Structure
 * [**LANGS**](./languages.md): Multi-Languages book
 * [**GLOSSARY**](./glossary.md): List of terms with descriptions


### PR DESCRIPTION
The readme link at http://help.gitbook.com/format/README.html should go to `./introduction.md` instead.